### PR TITLE
When parsing an empty array, use an empty array for the result, rathe…

### DIFF
--- a/src/Farse/Parse.fs
+++ b/src/Farse/Parse.fs
@@ -496,8 +496,9 @@ module Parse =
             let mutable i = 0
 
             let items =
-                element.GetArrayLength()
-                |> Array.zeroCreate
+                match element.GetArrayLength() with
+                | 0 -> [||]
+                | len -> Array.zeroCreate len
 
             while not error && enumerator.MoveNext() do
                 match parse enumerator.Current with


### PR DESCRIPTION
…r than allocating a new 0 length array for each operation.

Hi,
When doing some benchmarking on a parser at work, on some Json that often includes lots of empty arrays, I noticed that Farse seems to be allocating lots of 0 length arrays for the results, and wondered if it could avoid using Array.zeroCreate when GetArrayLength() returns 0?

A benchmark of my own parser gets this with the current Farse
```
| Method                 | Mean        | Error     | StdDev    | Gen0    | Gen1    | Allocated |
|----------------------- |------------:|----------:|----------:|--------:|--------:|----------:|
| ParseDefaultJsonSchema |    32.75 us |  0.644 us |  0.814 us |  0.9155 |       - |  11.58 KB |
| ParseLargeJsonSchema   | 2,058.48 us | 38.183 us | 35.716 us | 35.1563 | 15.6250 | 431.53 KB |
```

And when special casing 0 length arrays
```
| Method                 | Mean        | Error     | StdDev    | Gen0    | Gen1    | Allocated |
|----------------------- |------------:|----------:|----------:|--------:|--------:|----------:|
| ParseDefaultJsonSchema |    32.48 us |  0.621 us |  0.807 us |  0.8545 |       - |   10.9 KB |
| ParseLargeJsonSchema   | 2,049.39 us | 40.904 us | 42.006 us | 27.3438 | 11.7188 | 361.85 KB |
```

So, there's a big difference in allocations, though not really any performance change (for the record, the 'large' input here is 627KB of Json).

Anyway, putting this here in case you think it's useful.

Thanks.