### PR TITLE
Use a boolean active pattern for ActivePatterns.|Equals|

### DIFF
--- a/src/Farse/Internal.fs
+++ b/src/Farse/Internal.fs
@@ -114,9 +114,7 @@ module internal Internal =
     module ActivePatterns =
 
         let (|Equals|_|) actual expected =
-            if expected = ExpectedKind.fromKind actual
-            then Some ()
-            else None
+            expected = ExpectedKind.fromKind actual
 
         let (|Prop|Path|) (string:string) =
             if string.Contains('.')


### PR DESCRIPTION
Hi,

Not sure how much difference this makes in reality, but it's a tad simpler, so:

If I do a one-off profile run of some Json parsing in the visual studio memory profiler, I get this

<img width="1811" height="165" alt="image" src="https://github.com/user-attachments/assets/286a5b9f-2a6e-4a4e-a07e-e64d18f760fc" />

Where this active pattern seems to create lots on Option instances.
*But* I don't see that in benchmarkdotnet runs - it appears to not happen there (maybe it's the tiered jit or something optimising it more in that case, I'm not sure), so maybe it's not a real issue.

In any case, I wondered if making it a [boolean return pattern](https://learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9#partial-active-patterns-can-return-bool-instead-of-unit-option) would be an idea in general as it removes the options altogether, but is also simpler anyway.

Any thoughts?